### PR TITLE
Basic firecracker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ START_ENGINE  AUTO
 Also included are two macro's, "All Devices" and "All Lights", which map to the
 commands allon/alloff and lightson/lightsoff on housecode A.
 
+On, off, bright and dim commands can also be sent via the CM17A FireCracker module
+by setting "useFireCracker" to **true** in the configuration settings.
+
 # Installation
 
 1. Install homebridge using: npm install -g homebridge

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ running
        "name": "Heyu",
        "heyuExec": "/usr/local/bin/heyu",   //optional - defaults to /usr/local/bin/heyu
        "x10conf": "/etc/heyu/x10.conf",     //optional - defaults to /etc/heyu/x10.conf
+       "useFireCracker": false              //optional - If true, issues commands via the CM17A FireCracker module
        "cputemp": "cputemp"                 //optional - If present includes cpu TemperatureSensor
    }]
 ```


### PR DESCRIPTION
With this change, I've added a "useFireCracker" option to the configuration.  This involved moving the X10 commands into an object.  If the useFireCracker option is set to true, then the appropriate commands are overwritten with the FireCracker flavor.  There is probably a cleaner way to do this, so I'm open to any suggestions.  The end result is that the on, off, bright and dim commands are replaced with "fon", "foff", fbright", "fdim", etc.  If a CM17A module is present, then the commands will be sent via RF signals to the receiver which then sends them into the power line.
