### PR TITLE
Strengthen plugin against bad x10config

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ echo $cpuTemp1" C"
 
 * [ ] Improve performance of the plugin and responsiveness of the Home app by removing the get function.
 * [ ] Use tail rather than heyu monitor to monitor for events
-* [ ] Stop Missing HOUSECODE from x10.conf causing homebridge to crash during startup.
+* [x] Stop Missing HOUSECODE from x10.conf causing homebridge to crash during startup.
 * [ ] Bad x10.conf causing homebridge to crash during startup.
 
 # Credits

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ echo $cpuTemp1" C"
 * [ ] Improve performance of the plugin and responsiveness of the Home app by removing the get function.
 * [ ] Use tail rather than heyu monitor to monitor for events
 * [x] Stop Missing HOUSECODE from x10.conf causing homebridge to crash during startup.
-* [ ] Bad x10.conf causing homebridge to crash during startup.
+* [x] Bad x10.conf causing homebridge to crash during startup.
 * [ ] analyze queued up heyu commands and consolidate where possible (same command and same housecode)
 
 # Credits

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ echo $cpuTemp1" C"
 
 * [ ] Improve performance of the plugin and responsiveness of the Home app by removing the get function.
 * [ ] Use tail rather than heyu monitor to monitor for events
-* [ ] Stop Missing HOUSECODE from x10.conf causing homebridge to crash during startup.
+* [x] Stop Missing HOUSECODE from x10.conf causing homebridge to crash during startup.
 * [ ] Bad x10.conf causing homebridge to crash during startup.
 * [ ] analyze queued up heyu commands and consolidate where possible (same command and same housecode)
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var Accessory, Characteristic, PowerConsumption, Service, uuid;
 var exec = require('child_process').execFile;
 var spawn = require('child_process').spawn;
 var os = require("os");
+var fs = require('fs');
 var heyuExec, cputemp, x10conf, useFireCracker;
 var noMotionTimer;
 var X10Commands = {
@@ -64,7 +65,6 @@ function HeyuPlatform(log, config) {
 }
 
 function readX10config() {
-    var fs = require('fs');
     var x10confObject = {};
 
     var x10confData = fs.readFileSync(x10conf);
@@ -85,18 +85,19 @@ function readX10config() {
 }
 
 function readHousecode() {
-    var fs = require('fs');
-    var x10confObject = {};
 
-    var x10confData = fs.readFileSync(x10conf);
-    var pattern = new RegExp('\nHOUSECODE.*', 'ig');
+    var housecode = "A"; // heyu defualt
+    var x10confData = fs.readFileSync(x10conf, "utf8");
 
-    var match = [];
-    match = pattern.exec(x10confData);
-    var line = match[0].split(/[ \t]+/);
-    var housecode = line[1];
+    // filter out comments
+    x10confData = x10confData.replace(/#.*?\n/g, "\n");
+    var matches = x10confData.match(/HOUSECODE\s+([A-P])/i);
+    if (matches) {
+        housecode = matches[1];
+    }
     debug("HOUSECODE",housecode);
     return housecode;
+
 }
 
 function enableFireCracker() {

--- a/index.js
+++ b/index.js
@@ -119,10 +119,10 @@ function heyuShowAliases() {
 
   var aliases, lines, stdout;
 
-  stdout = execSync(this.config.heyuExec, ["show", "aliases"], {
+  stdout = execSync(heyuExec, ["show", "aliases"], {
     "encoding": "utf8"
   });
-  lines = stdout.split("\n").slice(1, -1);
+  lines = stdout.split("\n").slice(1, -2);
   aliases = lines.map(function (line) {
 
     var alias, words;
@@ -148,7 +148,7 @@ function readHousecode() {
 
   var housecode, matches, stdout;
 
-  stdout = execSync(this.config.heyuExec, ["info"], { encoding: "utf8" });
+  stdout = execSync(heyuExec, ["info"], { encoding: "utf8" });
   matches = stdout.match(/Housecode = ([A-P])/);
   if (matches) {
     housecode = matches[1];
@@ -185,7 +185,7 @@ HeyuPlatform.prototype = {
         "module": alias.moduleType
       };
 
-      this.log("Found in x10.conf: %s %s %s", device.name, device.housecode, device.module);
+      self.log("Found in x10.conf: %s %s %s", device.name, device.housecode, device.module);
       var accessory = new HeyuAccessory(self.log, device, null);
       foundAccessories.push(accessory);
       var housecode = device.housecode;
@@ -194,14 +194,14 @@ HeyuPlatform.prototype = {
     });
     // Built-in accessories and macro's
     {
-      var device;
+      var device = {};
       device.name = "All Devices";
       device.housecode = this.housecode;
       device.module = "Macro-allon";
       var accessory = new HeyuAccessory(self.log, device, null);
       foundAccessories.push(accessory);
     } {
-      var device;
+      var device = {};
       device.name = "All Lights";
       device.housecode = this.housecode;
       device.module = "Macro-lightson";

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var Accessory, Characteristic, PowerConsumption, Service, uuid;
 var exec = require('child_process').execFile;
 var spawn = require('child_process').spawn;
 var os = require("os");
+var fs = require('fs');
 var heyuExec, heyuQueue, cputemp, x10conf, useFireCracker;
 var noMotionTimer;
 var X10Commands = {
@@ -115,7 +116,6 @@ function HeyuPlatform(log, config) {
 }
 
 function readX10config() {
-  var fs = require('fs');
   var x10confObject = {};
 
   var x10confData = fs.readFileSync(x10conf);
@@ -136,18 +136,19 @@ function readX10config() {
 }
 
 function readHousecode() {
-  var fs = require('fs');
-  var x10confObject = {};
 
-  var x10confData = fs.readFileSync(x10conf);
-  var pattern = new RegExp('\nHOUSECODE.*', 'ig');
+  var housecode = "A"; // heyu defualt
+  var x10confData = fs.readFileSync(x10conf, "utf8");
 
-  var match = [];
-  match = pattern.exec(x10confData);
-  var line = match[0].split(/[ \t]+/);
-  var housecode = line[1];
-  debug("HOUSECODE", housecode);
+  // filter out comments
+  x10confData = x10confData.replace(/#.*?\n/g, "\n");
+  var matches = x10confData.match(/HOUSECODE\s+([A-P])/i);
+  if (matches) {
+    housecode = matches[1];
+  }
+  debug("HOUSECODE",housecode);
   return housecode;
+
 }
 
 function enableFireCracker() {


### PR DESCRIPTION
This should solve #12.

Uses `heyu` commands to parse the x10config file and read the output of commands like `heyu show aliases` and `heyu info` to extract the list of aliases and the default house code.