### PR TITLE
heyu dimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ echo $cpuTemp1" C"
 * [ ] expand module type coverage to all appliance and lamp types defined in the x10config man page for heyu
 * [ ] rewrite Modules Types Supported section above
 * [ ] improve consistency of dimming standard lamp modules by rounding dim levels to multiples of five
+* [ ] implement SmartHome's Implmentation of Pre-Set Dim
 * [ ] implement xpreset dimming for LM456-1 and others
 
 # Credits

--- a/README.md
+++ b/README.md
@@ -25,11 +25,17 @@ by setting "useFireCracker" to **true** in the configuration settings.
 
 # Modules Types Supported
 
-* Lamp Module ( Light Bulb ) - LM, LM12, LM465, StdLM
+* Lamp Module ( Light Bulb ) - All lamp modules supported by heyu
+     * including LM, LM12, LM465, StdLM
+     * and SL1LM, SL2LM, LL1LM, and LL2LM with Pre-set dim codes
+     * and LM465-1, LM-1, LM14A with Extended codes
 
-* Appliance Module ( Outlet ) - AM, AMS, AM12, StdAM
+* Appliance Module ( Outlet ) - All appliance modules supported by heyu
+    * including AM, AMS, AM12, StdAM
 
-* Wall Switch ( Switch ) - WS, WS-1, WS467, WS467-1, XPS3, StdWS
+* Wall Switch ( Switch ) - All wall switch modules support by heyu
+    * including WS, WS-1, WS467, WS467-1, XPS3, StdWS
+    * and WS467-1 and WS-1 with Extended codes
 
 * Motion Sensor - MS10, MS12, MS13, MS14, MS16
 
@@ -37,9 +43,8 @@ by setting "useFireCracker" to **true** in the configuration settings.
 
 * Insteon Modules accepting X10 Commands - SL2LM ( 2477D )
 
-Please note that only the lamp module and Insteon Module has the dimming feature,
-so if have a switch that you want to be able to dim, define it as a LM.  And if
-you have a lamp that you do not want to be able to dim, define it as a WS.
+Please note that all dimmable modules have the dimming feature. If
+you have a lamp or wall switch that you do not want to be able to dim, define it as a non-dimmable wall switch or appliance module.
 
 Motion Sensors, Reliability and Battery Life - As the motion sensor does not return
 any information regarding battery status, I'm using the daylight sensor feature of the
@@ -100,11 +105,10 @@ echo $cpuTemp1" C"
 * [x] Stop Missing HOUSECODE from x10.conf causing homebridge to crash during startup.
 * [x] Bad x10.conf causing homebridge to crash during startup.
 * [ ] analyze queued up heyu commands and consolidate where possible (same command and same housecode)
-* [ ] expand module type coverage to all appliance and lamp types defined in the x10config man page for heyu
-* [ ] rewrite Modules Types Supported section above
-* [ ] improve consistency of dimming standard lamp modules by rounding dim levels to multiples of five
-* [ ] implement SmartHome's Implmentation of Pre-Set Dim
-* [ ] implement xpreset dimming for LM456-1 and others
+* [x] expand module type coverage to all appliance and lamp types defined in the x10config man page for heyu
+* [x] rewrite Modules Types Supported section above
+* [x] implement SmartHome's Implementation of Pre-Set Dim
+* [x] implement xpreset dimming for LM456-1 and others
 
 # Credits
 

--- a/README.md
+++ b/README.md
@@ -113,4 +113,4 @@ echo $cpuTemp1" C"
 # Credits
 
 * W7RZL - Firecracker commands and additional modules
-* keithws - Command queueing
+* keithws - Command queueing and enhanced dimming

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ echo $cpuTemp1" C"
 * [x] Stop Missing HOUSECODE from x10.conf causing homebridge to crash during startup.
 * [x] Bad x10.conf causing homebridge to crash during startup.
 * [ ] analyze queued up heyu commands and consolidate where possible (same command and same housecode)
+* [ ] expand module type coverage to all appliance and lamp types defined in the x10config man page for heyu
+* [ ] rewrite Modules Types Supported section above
+* [ ] improve consistency of dimming standard lamp modules by rounding dim levels to multiples of five
+* [ ] implement xpreset dimming for LM456-1 and others
 
 # Credits
 

--- a/index.js
+++ b/index.js
@@ -669,11 +669,6 @@ HeyuAccessory.prototype = {
     var housecode;
     var command;
 
-    if (this.hasPartialSupportForExtendedCodes || this.hasSupportForOldPreSetDim) {
-      this.on_command = X10Commands.xon;
-      this.off_command = X10Commands.xoff;
-    }
-
     if (!this.on_command || !this.off_command) {
       this.log.warn("Ignoring request; No power command defined.");
       callback(new Error("No power command defined."));

--- a/index.js
+++ b/index.js
@@ -259,7 +259,7 @@ function HeyuAccessory(log, device, enddevice) {
   self.on_command = X10Commands.on;
   self.off_command = X10Commands.off;
   self.status_command = X10Commands.onstate;
-  self.brightness_command = X10Commands.rawlevel; // TODO dimlevel cannot be trusted
+  self.brightness_command = X10Commands.rawlevel; // dimlevel cannot be trusted
   self.statusHandling = "yes";
   self.dimmable = "yes";
 
@@ -654,6 +654,11 @@ HeyuAccessory.prototype = {
   setPowerState: function(powerOn, callback) {
     var housecode;
     var command;
+
+    if (this.hasPartialSupportForExtendedCodes || this.hasSupportForOldPreSetDim) {
+      this.on_command = X10Commands.xon;
+      this.off_command = X10Commands.xoff;
+    }
 
     if (!this.on_command || !this.off_command) {
       this.log.warn("Ignoring request; No power command defined.");

--- a/index.js
+++ b/index.js
@@ -294,23 +294,58 @@ HeyuPlatform.prototype.heyuEvent = function(self, accessory) {
   var other = accessory;
   switch (other.module) {
     case "AM":
-    case "AMS":
-    case "AM12":
     case "StdAM":
+    case "AM486":
+    case "AM466":
+    case "PAM01":
+    case "PAM02":
+    case "AM12":
+    case "SR227":
+    case "PA011":
+    case "AMS":
+    case "RR501":
+    case "PAT01":
+    case "RAIN8II":
     case "WS":
-    case "WS-1":
     case "WS467":
-    case "WS467-1":
+    case "WS13A":
     case "XPS3":
-    case "StdWS":
+    case "LM15A":
+    case "PSM04":
+    case "LM15":
+    case "AM14A":
+    case "AM15A":
+    case "PAM21":
+    case "PAM22":
+    case "SL1AM":
+    case "SL2AM":
+    case "RS114":
+    case "RF234":
       other.service.getCharacteristic(Characteristic.On)
         .getValue();
       break;
+    case "LM465-1":
+    case "LM-1":
     case "LM":
-    case "LM12":
-    case "LM465":
     case "StdLM":
+    case "LM465":
+    case "PLM01":
+    case "PLM03":
+    case "LM12":
+    case "LMS":
+    case "WS467-1":
+    case "WS-1":
+    case "LW10U":
+    case "WS12A":
+    case "XPD3":
+    case "LM14A":
+    case "PLM21":
+    case "SL1LM":
     case "SL2LM":
+    case "SL2380W":
+    case "LL1LM":
+    case "LL2LM":
+    case "LL2000STW":
       other.service.getCharacteristic(Characteristic.Brightness)
         .getValue();
       other.service.getCharacteristic(Characteristic.On)
@@ -394,10 +429,32 @@ HeyuAccessory.prototype = {
 
         services.push(this.service);
         break;
+      case "LM465-1":
+      case "LM-1":
       case "LM":
-      case "LM12":
-      case "LM465":
       case "StdLM":
+      case "LM465":
+      case "PLM01":
+      case "PLM03":
+      case "LM12":
+      case "LMS":
+      case "WS467-1":
+      case "WS-1":
+      case "LW10U":
+      case "WS12A":
+      case "XPD3":
+      case "LM14A":
+      case "PLM21":
+      case "SL1LM":
+      case "SL2LM":
+      case "SL2380W":
+      case "LL1LM":
+      case "LL2LM":
+      case "LL2000STW":
+      case "LM15A":
+      case "PSM04":
+      case "LM15":
+        // lamp modules (dimmable outlets and dimmable switches)
         this.log("StdLM: Adding %s %s as a %s", this.name, this.housecode, this.module);
         this.service = new Service.Lightbulb(this.name);
         this.service
@@ -418,7 +475,7 @@ HeyuAccessory.prototype = {
         services.push(this.service);
         break;
       case "SL2LM":
-        this.log("StdLM: Adding %s %s as a %s", this.name, this.housecode, this.module);
+        this.log("SL2LM: Adding %s %s as a %s", this.name, this.housecode, this.module);
         this.service = new Service.Lightbulb(this.name);
         this.service
           .getCharacteristic(Characteristic.On)
@@ -439,12 +496,27 @@ HeyuAccessory.prototype = {
         services.push(this.service);
         break;
       case "AM":
-      case "AMS":
-      case "AM12":
       case "StdAM":
+      case "AM486":
+      case "AM466":
+      case "PAM01":
+      case "PAM02":
+      case "AM12":
+      case "SR227":
+      case "PA011":
+      case "AMS":
+      case "RR501":
+      case "PAT01":
+      case "RAIN8II":
+      case "AM14A":
+      case "AM15A":
+      case "PAM21":
+      case "PAM22":
+        // appliance modules with outlets (non-dimmable outlets)
         this.log("StdAM: Adding %s %s as a %s", this.name, this.housecode, this.module);
         this.dimmable = "no"; // All Appliance modules are not dimmable
         this.service = new Service.Outlet(this.name);
++        // TODO technically the Outlet service requires a OutletInUse characterist (would always be true)
         this.service
           .getCharacteristic(Characteristic.On)
           .on('get', this.getPowerState.bind(this))
@@ -452,11 +524,14 @@ HeyuAccessory.prototype = {
         services.push(this.service);
         break;
       case "WS":
-      case "WS-1":
       case "WS467":
-      case "WS467-1":
+      case "WS13A":
       case "XPS3":
-      case "StdWS":
+      case "SL1AM":
+      case "SL2AM":
+      case "RS114":
+      case "RF234":
+        // appliance modules with switches (non-dimmable switches)
         this.log("StdWS: Adding %s %s as a %s", this.name, this.housecode, this.module);
         this.dimmable = "no"; // Technically some X10 switches are dimmable, but we're treating them as on/off
         this.service = new Service.Switch(this.name);


### PR DESCRIPTION
Long time coming, but this feature is now ready. I've been living and working on this since September. It adds support for all dimmable module types defined in the heyu man page, x10config, including the "new" LM456-1 and WS467-1. These modules, along with some others, support extended preset commands, which map very well to HomeKit dim levels.

I also updated the code for modules that support pre-set levels as well. The pre-set levels (1-32) are mapped to percentages using the [SmartHome Pre-set tables according to the X10 Knowledge base](http://kbase.x10.com/wiki/Using_Pre-Set_Dim).

I also experimented with using steps in the HomeKit levels, but ended up settling on 1 step because it provided the best UX in my experience. With the user selecting HomeKit levels (0-100), the mapping to extended preset levels (0-63) means the user gets the exact level they wanted 64% of the time. The other 36% of the time they are only off by one. For the Pre-set levels (1-32), the user gets the exact right level 31% of the time, is off by one 62% of the time and is off by two 7% of the time. The standard dim levels (1-22) present the worst case. The select dim level and the dim level returned by heyu can be up to 5% off.

I implemented all this in accordance with the available documentation, so it will work close the the theoretical ideal. However, I've also adjusted to real world use. For instance, I discovered the `heyu dimlevel` command is not very reliable, so I re-factored the getBrightness() function to always call `heyu rawlevel` and interpret the raw value by module type. I also discovered that while the extended preset levels are 0-63, heyu never returned a level above 62, so I adjusted my calculations accordingly.

There was one odd behavior that I couldn't get rid of. Pre-set dim modules go to 100% when they receive an `on` command and HomeKit sends an `on` command at the start of each dim. This is expressed as the jumping to full brightness and then dimming to the desired level. I tried a few different hacks, but they all had downsides. I believe the proper solution is queue optimization. By holding commands in the queue for a fraction of a second, I can add code to analyze the queue and drop any `on` commands that appear immediately before a `pre-set` command, since `pre-set` commands will turn the module `on`. Luckily, that is the next feature I'm working on and I already have a few basic optimizations working!

I knew X10 dimming was kind of a mess, but I wanted to get the best integration I could between X10 and HomeKit. Thank you so much for starting this project!