### PR TITLE
Fixed Crash with no CM11a present

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 [![NPM Downloads](https://img.shields.io/npm/dm/homebridge-heyu.svg?style=flat)](https://npmjs.org/package/homebridge-heyu)
 
-# Support is no longer available for the plugin.  
-
-## Everyone I have retired my last X10 device so I will no longer be able to work on issues with this plugin.  If you are an active user, and want to take over please let me know and we can look into transferring the plugin over.
-
 Supports X10 devices via heyu on the HomeBridge Platform. Tested with a CM11A
 Module connected via a USB Serial adapter. For device configuration, it parses
 the heyu configuration file /etc/heyu/x10.conf and creates an accessory for each
@@ -74,6 +70,7 @@ running
        "heyuExec": "/usr/local/bin/heyu",   //optional - defaults to /usr/local/bin/heyu
        "x10conf": "/etc/heyu/x10.conf",     //optional - defaults to /etc/heyu/x10.conf
        "useFireCracker": false              //optional - If true, issues commands via the CM17A FireCracker module
+       "housecode": "A"                     //optional - set housecode if no CM11a present
        "cputemp": "cputemp"                 //optional - If present includes cpu TemperatureSensor
    }]
 ```
@@ -118,3 +115,4 @@ echo $cpuTemp1" C"
 
 * W7RZL - Firecracker commands and additional modules
 * keithws - Command queueing and enhanced dimming
+* drmessano - Fix Housecode when no CM11a present

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@
 //       "heyuExec": "/usr/local/bin/heyu",   //optional - defaults to /usr/local/bin/heyu
 //       "x10conf": "/etc/heyu/x10.conf",     //optional - defaults to /etc/heyu/x10.conf
 //       "useFireCracker": false,             //optional - If true, uses CM17A FireCracker module to issue on/off commands
+//       "housecode": "A"                     //optional - set housecode if no CM11a present
 //       "cputemp": "cputemp"                 //optional - If present includes cpu TemperatureSensor
 //   }]
 
@@ -18,7 +19,7 @@ var exec = require('child_process').execFile;
 var execSync = require('child_process').execFileSync;
 var spawn = require('child_process').spawn;
 var os = require("os");
-var heyuExec, heyuQueue, cputemp, x10conf, useFireCracker;
+var heyuExec, heyuQueue, cputemp, x10conf, useFireCracker, housecode;
 var X10Commands = {
   on: "on",
   off: "off",
@@ -108,8 +109,8 @@ function HeyuPlatform(log, config) {
   x10conf = config.x10conf || "/etc/heyu/x10.conf";
   useFireCracker = config.useFireCracker || false;
   cputemp = config.cputemp;
-  this.housecode = readHousecode();
-
+  this.housecode = config.housecode || readHousecode();
+  
   if (useFireCracker) {
     enableFireCracker();
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-heyu",
-  "version": "0.3.29",
+  "version": "0.3.30",
   "description": "X10/Heyu plugin for HomeBridge",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/NorthernMan54/homebridge-heyu.git"
+    "url": "git+https://github.com/keithws/homebridge-heyu.git"
   },
   "keywords": [
     "x10",
@@ -23,12 +23,12 @@
   "dependencies": {
     "debug": "^2.2.0"
   },
-  "author": "NorthernMan54",
+  "author": "keithws",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/NorthernMan54/homebridge-heyu/issues"
+    "url": "https://github.com/keithws/homebridge-heyu/issues"
   },
-  "homepage": "https://github.com/NorthernMan54/homebridge-heyu#readme",
+  "homepage": "https://github.com/keithws/homebridge-heyu#readme",
   "devDependencies": {
     "eslint": "^5.16.0",
     "pre-commit": "^1.2.2"


### PR DESCRIPTION
Housecode check depends on a CM11a or Homebridge crashes.  Created a new config item to force "HOUSECODE" for those of us using other hardware.